### PR TITLE
Update to new Bonus stage styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This site creates social media sharing cards for the [Netlify blog](https://www.
 
 The images look something like this:
 
-![Add the title of the article you’re sharing! Wow! It’s so easy!](https://res.cloudinary.com/netlify/image/upload/c_fit,g_west,h_515,co_rgb:FFFFFFFF,l_text:netlify.com:Pacaembu-Bold.ttf_67:Add%20the%20title%20of%20the%20article%20you%E2%80%99re%20sharing!%20Wow!%20It%E2%80%99s%20so%20easy,w_1053,x_45,y_30/v1619121070/netlify.com/default-og-background.png)
+![Add the title of the article you’re sharing! Wow! It’s so easy!](https://res.cloudinary.com/netlify/image/upload/c_fit,g_west,h_400,co_rgb:FFFFFFFF,l_text:netlify.com:Pacaembu-Bold.ttf_57:Next.js%20on%20Netlify%3A%20Now%20with%20support%20for%20On-demand%20Builders%20and%20Distributed%20Persistent%20Rendering,w_1053,x_46/v1619123320/netlify.com/default-og-background-learn-more.png)
 
 To make your own, click the Deploy to Netlify button:
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This site creates social media sharing cards for the [Netlify blog](https://www.
 
 The images look something like this:
 
-![Add the title of the article you’re sharing! Wow! It’s so easy!](https://res.cloudinary.com/jlengstorf/image/upload/w_1300/g_west,c_fit,co_rgb:FFFFFFFF,w_1200,x_50,y_25,l_text:dillan.otf_110_line_spacing_-22:Add%20the%20title%20of%20the%20article%20you%E2%80%99re%20sharing!%20Wow!%20It%E2%80%99s%20so%20easy!/v1591839476/netlify/og.png)
+![Add the title of the article you’re sharing! Wow! It’s so easy!](https://res.cloudinary.com/netlify/image/upload/c_fit,g_west,h_515,co_rgb:FFFFFFFF,l_text:netlify.com:Pacaembu-Bold.ttf_67:Add%20the%20title%20of%20the%20article%20you%E2%80%99re%20sharing!%20Wow!%20It%E2%80%99s%20so%20easy,w_1053,x_45,y_30/v1619121070/netlify.com/default-og-background.png)
 
 To make your own, click the Deploy to Netlify button:
 

--- a/functions/get-image-url.js
+++ b/functions/get-image-url.js
@@ -5,8 +5,6 @@ exports.handler = async (event) => {
     statusCode: 200,
     body: `https://res.cloudinary.com/${
       process.env.CLOUDINARY_CLOUD_NAME
-    }/image/upload/w_1300/g_west,c_fit,co_rgb:FFFFFFFF,w_1200,x_50,y_25,l_text:dillan.otf_${size}_line_spacing_${
-      size * -0.2
-    }:${encodeURIComponent(caption)}/${process.env.CLOUDINARY_IMAGE_PUBLIC_ID}`,
+    }/image/upload/c_fit,g_west,h_515,co_rgb:FFFFFFFF,l_text:netlify.com:Pacaembu-Bold.ttf_${size}:${encodeURIComponent(caption)},w_1053,x_45,y_30/${process.env.CLOUDINARY_IMAGE_PUBLIC_ID}`,
   };
 };

--- a/functions/get-image-url.js
+++ b/functions/get-image-url.js
@@ -5,6 +5,6 @@ exports.handler = async (event) => {
     statusCode: 200,
     body: `https://res.cloudinary.com/${
       process.env.CLOUDINARY_CLOUD_NAME
-    }/image/upload/c_fit,g_west,h_515,co_rgb:FFFFFFFF,l_text:netlify.com:Pacaembu-Bold.ttf_${size}:${encodeURIComponent(caption)},w_1053,x_45,y_30/${process.env.CLOUDINARY_IMAGE_PUBLIC_ID}`,
+    }/image/upload/c_fit,g_west,h_400,co_rgb:FFFFFFFF,l_text:netlify.com:Pacaembu-Bold.ttf_${size}:${encodeURIComponent(caption)},w_1053,x_46/${process.env.CLOUDINARY_IMAGE_PUBLIC_ID}`,
   };
 };

--- a/src/index.md
+++ b/src/index.md
@@ -59,7 +59,7 @@ layout: default
   <input id="caption" name="caption" type="text" />
 
   <label for="size">If it doesn’t fit, you can adjust the font size here:</label>
-  <input id="size" name="size" type="number" value="110" min="10" />
+  <input id="size" name="size" type="number" value="67" min="10" />
 
   <button>Generate Image</button>
 </form>

--- a/src/index.md
+++ b/src/index.md
@@ -59,7 +59,7 @@ layout: default
   <input id="caption" name="caption" type="text" />
 
   <label for="size">If it doesn’t fit, you can adjust the font size here:</label>
-  <input id="size" name="size" type="number" value="67" min="10" />
+  <input id="size" name="size" type="number" value="57" min="10" />
 
   <button>Generate Image</button>
 </form>


### PR DESCRIPTION
⚠️ ⚠️ This assume using Netlify's Cloudinary creds ⚠️ ⚠️ 

Small update to match bonus stage style. Should give you something like this:

`CLOUDINARY_IMAGE_PUBLIC_ID` should be: `v1619123320/netlify.com/default-og-background-learn-more.png`



![](https://res.cloudinary.com/netlify/image/upload/c_fit,g_west,h_400,co_rgb:FFFFFFFF,l_text:netlify.com:Pacaembu-Bold.ttf_57:Next.js%20on%20Netlify%3A%20Now%20with%20support%20for%20On-demand%20Builders%20and%20Distributed%20Persistent%20Rendering,w_1053,x_46/v1619123320/netlify.com/default-og-background-learn-more.png)
